### PR TITLE
App 79/call before js module fix

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -75,7 +75,8 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() {
-        boolean hasActiveCatalystInstance = mAppLifecycleFacade.getRunningReactContext().hasActiveCatalystInstance();
+        ReactContext reactContext = mAppLifecycleFacade.getRunningReactContext();
+        boolean hasActiveCatalystInstance = reactContext != null && reactContext.hasActiveCatalystInstance();
         if (!mAppLifecycleFacade.isAppVisible() || !hasActiveCatalystInstance) {
             postNotification(null);
         }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -17,7 +17,6 @@ import android.util.Log;
 import androidx.core.text.HtmlCompat;
 
 import com.facebook.react.bridge.ReactContext;
-import com.wix.reactnativenotifications.Defs;
 import com.wix.reactnativenotifications.R;
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
@@ -75,11 +74,14 @@ public class PushNotification implements IPushNotification {
     }
 
     @Override
-    public void onReceived() throws InvalidNotificationException {
-        if (!mAppLifecycleFacade.isAppVisible()) {
+    public void onReceived() {
+        boolean hasActiveCatalystInstance = mAppLifecycleFacade.getRunningReactContext().hasActiveCatalystInstance();
+        if (!mAppLifecycleFacade.isAppVisible() || !hasActiveCatalystInstance) {
             postNotification(null);
         }
-        notifyReceivedToJS();
+        if (hasActiveCatalystInstance) {
+            notifyReceivedToJS();
+        }
     }
 
     @Override
@@ -139,15 +141,11 @@ public class PushNotification implements IPushNotification {
     }
 
     protected void dispatchUponVisibility() {
-        mAppLifecycleFacade.addVisibilityListener(getIntermediateAppVisibilityListener());
+        mAppLifecycleFacade.addVisibilityListener(mAppVisibilityListener);
 
         // Make the app visible so that we'll dispatch the notification opening when visibility changes to 'true' (see
         // above listener registration).
         launchOrResumeApp();
-    }
-
-    protected AppVisibilityListener getIntermediateAppVisibilityListener() {
-        return mAppVisibilityListener;
     }
 
     protected PendingIntent getCTAPendingIntent(int notificationId) {


### PR DESCRIPTION
I wasn't able to reproduce this crash when running on Degbu & Release mode, but because of the crash report I was able to add a fix according to this issue: https://github.com/OneSignal/react-native-onesignal/issues/877