### PR TITLE
APP-149/ios_lockscreen_mfa

### DIFF
--- a/lib/src/adapters/CompletionCallbackWrapper.ts
+++ b/lib/src/adapters/CompletionCallbackWrapper.ts
@@ -48,9 +48,10 @@ export class CompletionCallbackWrapper {
     callback: Function
   ): (
     notification: object,
+    completion: () => void,
     actionResponse?: NotificationActionResponse
   ) => void {
-    return (notification, actionResponse) => {
+    return (notification, _completion, actionResponse) => {
       const completion = () => {
         if (Platform.OS === 'ios') {
           this.nativeCommandsSender.finishHandlingAction(


### PR DESCRIPTION
This missing code occurred during the merge from the Wix version to 3.4